### PR TITLE
Fixed storageProvider typings

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,7 +8,7 @@ declare module 'use-dark-mode' {
     element?: HTMLElement; // The element to apply the className. Default = `document.body`
     onChange?: (val?: boolean) => void; // Overide the default className handler with a custom callback.
     storageKey?: string; // Specify the `localStorage` key. Default = "darkMode". Set to `null` to disable persistent storage.
-    storageProvider?: WindowLocalStorage; // A storage provider. Default = `localStorage`.
+    storageProvider?: Storage; // A storage provider. Default = `localStorage`.
     global?: Window; // The global object. Default = `window`.
   }
 


### PR DESCRIPTION
According to the code, you pass `storageProvider` to the `use-persisted-state`, and it uses `getItem` directly from it, not from `localStorage` property:

https://github.com/donavon/use-persisted-state/blob/develop/src/createStorage.js#L3