### PR TITLE
Add a demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Here is a list of apps build with `use-dark-mode`.
 If you have an app you would like to include on this list, open a PR.
 
 * [Demo App on CodeSandbox](https://codesandbox.io/s/mzj64x80ny) - by [@donavon](https://twitter.com/donavon)
+* [Demo App using NextJS](https://codesandbox.io/s/lively-waterfall-hugvk?file=/pages/index.jsx) - by [@Shareef](https://portfolio.shareef.vercel.app/)
 
 ## License
 


### PR DESCRIPTION
Add a demo app using NextJS to help other implementing dark mode in their NextJS project