### PR TITLE
Version 2.3.2 -> Version 2.4.0 (Proposed): Update React & React-Dom to 17.0.1.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "use-dark-mode",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8096,27 +8096,24 @@
       }
     },
     "react": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.8.0.tgz",
-      "integrity": "sha512-g+nikW2D48kqgWSPwNo0NH9tIGG3DsQFlrtrQ1kj6W77z5ahyIHG0w8kPpz4Sdj6gyLnz0lEd/xsjOoGge2MYQ==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.1.tgz",
+      "integrity": "sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.13.0"
+        "object-assign": "^4.1.1"
       }
     },
     "react-dom": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.0.tgz",
-      "integrity": "sha512-dBzoAGYZpW9Yggp+CzBPC7q1HmWSeRc93DWrwbskmG1eHJWznZB/p0l/Sm+69leIGUS91AXPB/qB3WcPnKx8Sw==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.1.tgz",
+      "integrity": "sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.13.0"
+        "scheduler": "^0.20.1"
       }
     },
     "react-testing-library": {
@@ -10400,9 +10397,9 @@
       "dev": true
     },
     "scheduler": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.0.tgz",
-      "integrity": "sha512-w7aJnV30jc7OsiZQNPVmBc+HooZuvQZIZIShKutC3tnMFMkcwVN9CZRRSSNw03OnSCKmEkK8usmwcw6dqBaLzw==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
+      "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "tag": "latest"
   },
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "A custom React Hook to help you implement a \"dark mode\" component.",
   "main": "dist/use-dark-mode.js",
   "umd:main": "dist/use-dark-mode.umd.js",
@@ -45,13 +45,13 @@
     "jest": "^23.6.0",
     "jest-dom": "^3.0.0",
     "microbundle": "^0.9.0",
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
     "react-testing-library": "^5.5.0",
     "rimraf": "^2.6.2"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": "^17.0.1"
   },
   "jest": {
     "coverageThreshold": {


### PR DESCRIPTION
This closes issue #70. This PR is an alternative to PR #68 and would update the semver of use-dark-mode from 2.3.2 to 2.4.0 to reflect the new peer dependency (React ^16.8 -> React ^17.0.1).

No code needs to be changed, as existing use-dark-mode v2.3.1 works fine with React 17; see: https://codesandbox.io/s/usedarkmode-demo-forked-fo70t?file=/src/App.js (But I took out the import React from "react" statement! ha!)