### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*		text eol=lf


### PR DESCRIPTION
This .gitattributes file will force Windows developers to check out LF line endings instead of the default "auto" behavior (CRLF check out, LF check in).

This is a quality-of-life improvement for Windows developers, who will otherwise need to manually fix line endings after forking the repository in order to avoid ESLint (prettier/prettier) line ending errors ("Remove CR").

References:
https://git-scm.com/docs/gitattributes#_end_of_line_conversion
https://dev.to/deadlybyte/please-add-gitattributes-to-your-git-repository-1jld#gitattributes-reset