### PR TITLE
Types: Allow passing lazy initial state getter

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -26,7 +26,7 @@ declare module 'use-dark-mode' {
    * A custom React Hook to help you implement a "dark mode" component for your application.
    */
   export default function useDarkMode(
-    initialState?: boolean,
+    initialState?: boolean | (() => boolean),
     config?: DarkModeConfig
   ): DarkMode;
 }


### PR DESCRIPTION
This argument is passed to `useState` and therefore can accept a lazy initial state getter. I've had to `@ts-ignore` some usage of the hook so that I can pass a function here.

See https://github.com/NorfolkDev/norfolkdevelopers-website/blob/39c988376c38976f9eaa2dfac3638c6fd938ec14/src/components/DarkModeToggle.tsx#L7-L10
