### PR TITLE
Amend the type declaration of storageKey to reflect null possibility

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,7 +7,7 @@ declare module 'use-dark-mode' {
     classNameLight?: string; // A className to set "light mode". Default = "light-mode".
     element?: HTMLElement; // The element to apply the className. Default = `document.body`
     onChange?: (val?: boolean) => void; // Overide the default className handler with a custom callback.
-    storageKey?: string; // Specify the `localStorage` key. Default = "darkMode". Set to `null` to disable persistent storage.
+    storageKey?: string | null; // Specify the `localStorage` key. Default = "darkMode". Set to `null` to disable persistent storage.
     storageProvider?: WindowLocalStorage; // A storage provider. Default = `localStorage`.
     global?: Window; // The global object. Default = `window`.
   }


### PR DESCRIPTION
I might be wrong here but the question mark in `storageKey?` infers the value to be a `string` or `undefined`. The documentation says it's possible for the value to be null so I've amended the definition here to match that.